### PR TITLE
Support multiple app locations server from the same package

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,92 @@ yarn ticket_sidebar:start
 !! Use any other application names instead of `ticket_sidebar` !!
 By default this will execute `yarn dev` script in `ticket_sidebar` folder, where your framework rests.
 
+### Change dev ports
+
+There might be a case where your framework package runs on a non-standard port, i.e. - http://localhost:`3005`
+If so, you can specify dev port for your local development for each application (package) separately.
+This will allow you to run multiple packages and they will be correctly reflected in `manifest.json` file.
+To do so:
+- head over to `packages/zendesk`
+- you can add `dev:port` and `dev:url` to any application listed in the `support` listed
+For example, given the following list:
+```
+"support": {
+	"ticket_sidebar": {
+		"url": "assets/ticket_sidebar/index.html",
+		"size": {
+			"height": "500px",
+			"width": "340px"
+		},
+		"flexible": true
+	},
+	"nav_bar": {
+		"url": "assets/nav_bar/index.html",
+		"size": {
+			"height": "500px",
+			"width": "340px"
+		},
+		"flexible": true
+	}
+}
+```
+
+You can specify different URL and Port for each app like so:
+
+```
+"support": {
+	"ticket_sidebar": {
+		"url": "assets/ticket_sidebar/index.html",
+		"size": {
+			"height": "500px",
+			"width": "340px"
+		},
+		"flexible": true,
+		"dev:url": "localhost",
+		"dev:port": 3500,
+
+	},
+	"nav_bar": {
+		"url": "assets/nav_bar/index.html",
+		"size": {
+			"height": "500px",
+			"width": "340px"
+		},
+		"flexible": true,
+		"dev:url": "localhost",
+		"dev:port": 4000,
+	}
+}
+
+```
+
+This will ensure in the manifest file generated like so:
+
+```
+"support": {
+	"ticket_sidebar": {
+		"url": "http://localhost:3500",
+		"size": {
+			"height": "500px",
+			"width": "340px"
+		},
+		"flexible": true,
+	},
+	"nav_bar": {
+		"url": "http://localhost:4000",
+		"size": {
+			"height": "500px",
+			"width": "340px"
+		},
+		"flexible": true,
+	}
+}
+
+```
+
+NOTICE: properties `dev:port` and `dev:url` are automatically removed by boilerplate, as those are non-production properties of `manifest.json`, so they are cleaned up.
+
+
 ## Build for production
 
 1. Inside your project directory use build script from `package.json` file

--- a/packages/zendesk/manifest.json
+++ b/packages/zendesk/manifest.json
@@ -10,7 +10,7 @@
   "location": {
     "support": {
       "ticket_sidebar": {
-        "url": "assets/index.html",
+        "url": "assets/ticket_sidebar/index.html",
         "size": {
           "height": "500px",
           "width": "340px"

--- a/packages/zendesk/scripts/build.mjs
+++ b/packages/zendesk/scripts/build.mjs
@@ -3,7 +3,12 @@ import fs from "fs-extra";
 const currentDir = process.cwd();
 const destinationDir = process.env.INIT_CWD + "/dist";
 const env = process.env.ENV;
-const COPY_LIST = ["assets", "translations", "manifest.json"];
+const COPY_LIST = [
+  "assets",
+  "translations",
+  "manifest.json",
+  "zcli.apps.config.json",
+];
 
 const shouldBeCopied = (fileName) => COPY_LIST.includes(fileName);
 

--- a/packages/zendesk/sdk/examples/multiple-apps-same-package/README.md
+++ b/packages/zendesk/sdk/examples/multiple-apps-same-package/README.md
@@ -1,0 +1,13 @@
+## Multiple applications have the same package as source
+
+This `manifest.json` gives an example of how to have multiple Support applications, using the same `package/` as source.
+It allows to not copy paste packages and develop application from the same codebase.
+Be careful to handle the Zendesk SDK's differences for different applications.
+
+### Properties
+
+In the example `manifest.json` you can see some properties added, that are not expected by Zendesk SDK:
+- `dev:url` - specify your own localhost or something else
+- `dev:port` - specify the port where your application is running
+
+This way you can have multiple UI frameworks working at the same time for different application locations.

--- a/packages/zendesk/sdk/examples/multiple-apps-same-package/manifest.json
+++ b/packages/zendesk/sdk/examples/multiple-apps-same-package/manifest.json
@@ -1,0 +1,48 @@
+{
+	"name": "Vite Boilerplate",
+	"author": {
+		"name": "OlegGulevskyy",
+		"email": "oleggulevskyy@gmail.com",
+		"url": "https://github.com/OlegGulevskyy/zendesk-vite-boilerplate"
+	},
+	"defaultLocale": "en",
+	"private": true,
+	"location": {
+		"support": {
+			"ticket_sidebar": {
+				"url": "assets/ticket_sidebar/index.html",
+				"size": {
+					"height": "500px",
+					"width": "340px"
+				},
+				"flexible": true
+			},
+			"organization_sidebar": {
+				"url": "assets/ticket_sidebar/index.html",
+				"size": {
+					"height": "500px",
+					"width": "340px"
+				},
+				"flexible": true
+			},
+			"new_ticket_sidebar": {
+				"url": "assets/ticket_sidebar/index.html",
+				"size": {
+					"height": "500px",
+					"width": "340px"
+				},
+				"flexible": true,
+				"dev:url": "localhost",
+				"dev:port": "3000"
+			},
+			"nav_bar": {
+				"url": "assets/nav_bar/index.html",
+				"dev:url": "localhost",
+				"dev:port": "3001"
+			}
+		}
+	},
+	"version": "1.0.0",
+	"frameworkVersion": "2.0"
+}
+


### PR DESCRIPTION
## Multiple applications have the same package as source

This `manifest.json` gives an example of how to have multiple Support applications, using the same `package/` as source.
It allows to not copy paste packages and develop application from the same codebase.
Be careful to handle the Zendesk SDK's differences for different applications.

### Properties

In the example `manifest.json` you can see some properties added, that are not expected by Zendesk SDK:
- `dev:url` - specify your own localhost or something else
- `dev:port` - specify the port where your application is running

This way you can have multiple UI frameworks working at the same time for different application locations.